### PR TITLE
removed unnecessary filters in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,5 @@
-.git*
 test/
 .DS_Store
 lib-cov
-node_modules
 coverage.html
 html-report


### PR DESCRIPTION
npm самостоятельно исключает директории `.git` и `node_moduels` при публикации модуля.
А явное исключение `node_modules` вообще ломает такую фичу как bundledDependencies.
